### PR TITLE
fix: allow changesets action to create version PRs

### DIFF
--- a/scripts/setup-github.sh
+++ b/scripts/setup-github.sh
@@ -40,12 +40,12 @@ gh api --method PUT "repos/${REPO}/vulnerability-alerts" >/dev/null
 echo "→ Enabling Dependabot security update PRs…"
 gh api --method PUT "repos/${REPO}/automated-security-fixes" >/dev/null
 
-echo "→ Setting Actions workflow token to read-only by default…"
+echo "→ Setting Actions workflow token to read-only by default (PR creation allowed for changesets)…"
 gh api --method PUT "repos/${REPO}/actions/permissions/workflow" \
 	--input - <<'EOF'
 {
   "default_workflow_permissions": "read",
-  "can_approve_pull_request_reviews": false
+  "can_approve_pull_request_reviews": true
 }
 EOF
 


### PR DESCRIPTION
## Summary

- Enable `can_approve_pull_request_reviews` in `setup-github.sh` so `changesets/action` can open release PRs while keeping default workflow permissions read-only.

## Test plan

- [x] Repo setting already applied manually
- [ ] Merge and confirm future `changesets/action/version` runs can open PRs